### PR TITLE
🐛 64 - Set table download url

### DIFF
--- a/components/pages/repository/RepoTable.tsx
+++ b/components/pages/repository/RepoTable.tsx
@@ -206,6 +206,7 @@ const getTableStyle = (theme: typeof defaultTheme) => css`
 
 const RepoTable = (props: PageContentProps) => {
   const { NEXT_PUBLIC_ARRANGER_API, NEXT_PUBLIC_ARRANGER_PROJECT_ID } = getConfig();
+
   return (
     <div css={(theme) => getTableStyle(theme)}>
       <Table

--- a/components/pages/repository/RepoTable.tsx
+++ b/components/pages/repository/RepoTable.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/core';
 import dynamic from 'next/dynamic';
+import urlJoin from 'url-join';
 
 import { PageContentProps } from './index';
 import defaultTheme from '../../theme';
+import { getConfig } from '../../../global/config';
 
 const Table = dynamic(
   () => import('@arranger/components/dist/Arranger').then((comp) => comp.Table),
@@ -203,6 +205,7 @@ const getTableStyle = (theme: typeof defaultTheme) => css`
 `;
 
 const RepoTable = (props: PageContentProps) => {
+  const { NEXT_PUBLIC_ARRANGER_API, NEXT_PUBLIC_ARRANGER_PROJECT_ID } = getConfig();
   return (
     <div css={(theme) => getTableStyle(theme)}>
       <Table
@@ -210,6 +213,7 @@ const RepoTable = (props: PageContentProps) => {
         showFilterInput={false}
         columnDropdownText={'Columns'}
         exportTSVText={'Download'}
+        downloadUrl={urlJoin(NEXT_PUBLIC_ARRANGER_API, NEXT_PUBLIC_ARRANGER_PROJECT_ID, 'download')}
       />
     </div>
   );


### PR DESCRIPTION
Setting downloadUrl prop explicitly on repo table, for some reason Arranger was not constructing this url with the configured server domain.
Download still does not work, see this [comment](https://github.com/overture-stack/roadmap/issues/64#issuecomment-780085236) in the ticket