### PR TITLE
🐛 41 - Remove incorrect import. Temporary typing

### DIFF
--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -6,6 +6,21 @@ import { useTheme } from 'emotion-theming';
 import defaultTheme from './theme';
 import { Avatar, ChevronDown } from './theme/icons';
 import useAuthContext from '../global/hooks/useAuthContext';
+import { UserWithId } from '../global/types';
+
+const getDisplayName = (user?: UserWithId) => {
+  const greeting = 'Hello';
+  if (user) {
+    if (user.firstName) {
+      return `${greeting}, ${user.firstName}`;
+    } else if (user.lastName) {
+      return `${greeting}, ${user.lastName}`;
+    } else if (user.email) {
+      return `${greeting}, ${user.email}`;
+    }
+  }
+  return greeting;
+};
 
 const CurrentUser = () => {
   const { user } = useAuthContext();
@@ -30,7 +45,7 @@ const CurrentUser = () => {
           max-width: 142px;
         `}
       >
-        Hello, {user?.firstName}
+        {getDisplayName(user)}
       </span>
     </div>
   );

--- a/global/types.ts
+++ b/global/types.ts
@@ -32,11 +32,11 @@ export interface User {
   lastName: string;
   createdAt: number;
   lastLogin: number;
-  preferredLanguage?: Language;
-  providerType: ProviderType;
-  providerSubjectId: string;
+  preferredLanguage?: string;
 }
 
+// will update User to include providerSubjectId and providerType once new version of ego-token-utils for Ego 4.x.x is available
+// preferredLanguage can be updated to enum
 export type EgoJwtData = {
   iat: number;
   exp: number;
@@ -52,4 +52,9 @@ export type EgoJwtData = {
 
 export interface UserWithId extends User {
   id: string;
+}
+
+export interface UserWithProviderInfo extends UserWithId {
+  providerType: ProviderType;
+  providerSubjectId: string;
 }

--- a/global/utils/egoTokenUtils.ts
+++ b/global/utils/egoTokenUtils.ts
@@ -9,12 +9,15 @@ const TokenUtils = createEgoUtils(getConfig().NEXT_PUBLIC_EGO_PUBLIC_KEY);
 export const isValidJwt = (egoJwt: string | undefined) => !!egoJwt && TokenUtils.isValidJwt(egoJwt);
 
 export const decodeToken = memoize((egoJwt?: string) =>
-  egoJwt ? TokenUtils.decodeToken(egoJwt) : null,
+  egoJwt && isValidJwt(egoJwt) ? TokenUtils.decodeToken(egoJwt) : null,
 );
 
-export const extractUser: (decodedToken: EgoJwtData) => UserWithId | {} = (decodedToken) => {
+// EgoJwtData will need to be updated in ego-token-utils to include new User type in Ego 4.x.x
+// that includes providerSubjectId and providerType, and removes name
+// matching older version for now
+export const extractUser = (decodedToken: EgoJwtData) => {
   if (decodedToken) {
     return { ...decodedToken?.context.user, id: decodedToken?.sub };
   }
-  return {};
+  return undefined;
 };


### PR DESCRIPTION
Removes incorrect import that broke build
Adds temporary typing to authContext user until there is a version of `ego-token-utils` for Ego 4.x.x.
Conditional display name for user dropdown