### PR TITLE
adjust grid header and footer rows based on theme

### DIFF
--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -34,8 +34,8 @@ const PageLayout = ({ children, subtitle }: { children: ReactNode; subtitle?: st
       <div
         css={(theme) => css`
           display: grid;
-          grid-template-rows: 50px 1fr;
-          min-height: 100vh;
+          grid-template-rows: ${theme.dimensions.navbar.height}px 1fr ${theme.dimensions.footer.height}px;
+          height: 100%;
           ${theme.typography.regular}
           color: ${theme.colors.black};
         `}

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -167,12 +167,12 @@ const UserDropdown = () => {
       )}
       {open && (
         <ul
-          css={css`
+          css={theme => css`
             width: 100%;
             list-style: none;
             padding: 0;
             position: absolute;
-            top: 51px;
+            top: ${theme.dimensions.navbar.height}px;
             left: 0;
             margin: 0;
           `}

--- a/components/pages/explorer/PageContent.tsx
+++ b/components/pages/explorer/PageContent.tsx
@@ -31,6 +31,7 @@ const PageContent = (props: PageContentProps) => {
     <div
       css={css`
         flex: 1;
+        width: 100vw;
       `}
     >
       <div
@@ -42,10 +43,8 @@ const PageContent = (props: PageContentProps) => {
       >
         <div
           css={(theme) => css`
-            flex: 3;
+            flex: 0 0 ${theme.dimensions.facets.width}px;
             flex-direction: column;
-            min-width: ${theme.dimensions.facets.minWidth}px;
-            max-width: ${theme.dimensions.facets.maxWidth}px;
             background-color: ${theme.colors.white};
             z-index: 1;
             ${theme.shadow.right};

--- a/components/theme/dimensions.ts
+++ b/components/theme/dimensions.ts
@@ -27,8 +27,7 @@ const dimensions = {
     height: 47,
   },
   facets: {
-    minWidth: 250,
-    maxWidth: 270,
+    width: 250,
   },
   labIcon: {
     height: 35,


### PR DESCRIPTION
While the header and footer heights can already be set in the theme, the page layout grid doesn't currently adjust accordingly when you customise the contants for a different theme.

Furthermore, we noticed at the VirusSeq project that given a small screen size, the current layout settings generate an overflow in the viewfinder, leading to an unnecessary second set of scrollbars that complicate the app's usability.

These changes address all that.
_**Note:** the overflowing buttons inside of Arranger's own table, etc. will be handled in the library at a later point._

---

Before (with the code currently in `develop`):

![image](https://user-images.githubusercontent.com/2107110/113769763-57d72600-96ef-11eb-9f09-00f95a47be5e.png)

After:

![image](https://user-images.githubusercontent.com/2107110/113769371-ebf4bd80-96ee-11eb-8569-642622e90377.png)
