### PR TITLE
💄 Correct provider display names. Clean up provider details

### DIFF
--- a/components/pages/login/index.tsx
+++ b/components/pages/login/index.tsx
@@ -2,14 +2,7 @@ import { css } from '@emotion/core';
 import urlJoin from 'url-join';
 
 import PageLayout from '../../PageLayout';
-import {
-  GoogleLogo,
-  FacebookLogo,
-  GitHubLogo,
-  OrcidLogo,
-  LinkedInLogo,
-  Illustration,
-} from '../../theme/icons';
+import { Illustration } from '../../theme/icons';
 
 import { IconProps } from '../../theme/icons/types';
 import { getConfig } from '../../../global/config';
@@ -17,6 +10,8 @@ import { getConfig } from '../../../global/config';
 import { usePageQuery } from '../../../global/hooks/usePageContext';
 import { trim } from 'lodash';
 import ErrorNotification from '../../ErrorNotification';
+import providerMap, { ProviderDetail } from '../../../global/utils/providerTypeMap';
+import { ProviderType } from '../../../global/types';
 
 const LoginButton = ({
   Icon,
@@ -88,30 +83,6 @@ const LoginButton = ({
       </div>
     </a>
   );
-};
-
-enum ProviderType {
-  GOOGLE = 'GOOGLE',
-  ORCID = 'ORCID',
-  LINKEDIN = 'LINKEDIN',
-  GITHUB = 'GITHUB',
-  // FACEBOOK = 'FACEBOOK'
-}
-
-type ProviderDetail = {
-  displayName: string;
-  path: string;
-  icon: any;
-};
-type ProviderMap = { [k in ProviderType]: ProviderDetail };
-
-const providerMap: ProviderMap = {
-  [ProviderType.GOOGLE]: { displayName: 'Google', path: 'google', icon: GoogleLogo },
-  [ProviderType.ORCID]: { displayName: 'ORCiD', path: 'orcid', icon: OrcidLogo },
-  [ProviderType.GITHUB]: { displayName: 'GitHub', path: 'github', icon: GitHubLogo },
-  [ProviderType.LINKEDIN]: { displayName: 'LinkedIn', path: 'linkedin', icon: LinkedInLogo },
-  // Facebook will be hidden until provider implementation is fixed in Ego https://github.com/overture-stack/ego/issues/555
-  // [ProviderType.FACEBOOK]: { displayName: 'Facebook', path: '', icon: FacebookLogo },
 };
 
 const LoginPage = () => {

--- a/components/pages/user/AuthenticatedBadge.tsx
+++ b/components/pages/user/AuthenticatedBadge.tsx
@@ -1,29 +1,14 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { capitalize } from 'lodash';
 import { useTheme } from 'emotion-theming';
 
-import { ProviderType } from '../../../global/types';
-
 import defaultTheme from '../../theme';
-import {
-  GoogleLogo,
-  FacebookLogo,
-  GitHubLogo,
-  OrcidLogo,
-  LinkedInLogo,
-  Checkmark,
-} from '../../theme/icons';
+import { Checkmark } from '../../theme/icons';
+import { ProviderType } from '../../../global/types';
+import providerMap from '../../../global/utils/providerTypeMap';
 
-const providerIcons: { [k in ProviderType]: React.ElementType } = {
-  GOOGLE: GoogleLogo,
-  GITHUB: GitHubLogo,
-  LINKEDIN: LinkedInLogo,
-  ORCID: OrcidLogo,
-};
-
-const AuthenticatedBadge = ({ provider }: { provider?: ProviderType }) => {
-  const IconComponent = provider ? providerIcons[provider] : null;
+const AuthenticatedBadge = ({ provider }: { provider: ProviderType }) => {
+  const IconComponent = providerMap[provider].icon;
   const theme: typeof defaultTheme = useTheme();
   return (
     <div
@@ -58,7 +43,7 @@ const AuthenticatedBadge = ({ provider }: { provider?: ProviderType }) => {
           color: ${theme.colors.accent_dark};
         `}
       >
-        Authenticated with {capitalize(provider)}
+        Authenticated with {providerMap[provider].displayName}
       </span>
       <Checkmark height={15} width={15} fill={theme.colors.primary} />
     </div>

--- a/components/pages/user/index.tsx
+++ b/components/pages/user/index.tsx
@@ -62,14 +62,14 @@ const UserComponent = () => {
           justify-content: center;
         `}
       >
-        <FlexDiv
-          css={css`
-            flex-direction: column;
-            margin: 1rem 2rem;
-            width: 800px;
-          `}
-        >
-          {!isEmpty(user) && (
+        {user && (
+          <FlexDiv
+            css={css`
+              flex-direction: column;
+              margin: 1rem 2rem;
+              width: 800px;
+            `}
+          >
             <UserInfoContainer>
               <FlexDiv
                 css={css`
@@ -82,15 +82,15 @@ const UserComponent = () => {
                     margin-left: 1rem;
                   `}
                 >
-                  <UserTitle>{`${user?.firstName} ${user?.lastName}`}</UserTitle>
-                  <UserEmail>{user?.email || ''}</UserEmail>
+                  <UserTitle>{`${user.firstName} ${user.lastName}`}</UserTitle>
+                  <UserEmail>{user.email || ''}</UserEmail>
                 </div>
               </FlexDiv>
-              <AuthenticatedBadge provider={user?.providerType} />
+              <AuthenticatedBadge provider={user.providerType} />
             </UserInfoContainer>
-          )}
-          {!isEmpty(user) && <ApiTokenInfo />}
-        </FlexDiv>
+            <ApiTokenInfo />
+          </FlexDiv>
+        )}
       </FlexDiv>
     </StyledPageLayout>
   );

--- a/global/utils/providerTypeMap.tsx
+++ b/global/utils/providerTypeMap.tsx
@@ -1,0 +1,21 @@
+import { GitHubLogo, GoogleLogo, LinkedInLogo, OrcidLogo } from '../../components/theme/icons';
+import { ProviderType } from '../types';
+
+export type ProviderDetail = {
+  displayName: string;
+  path: string;
+  icon: any;
+};
+
+export type ProviderMap = { [k in ProviderType]: ProviderDetail };
+
+const providerMap: ProviderMap = {
+  [ProviderType.GOOGLE]: { displayName: 'Google', path: 'google', icon: GoogleLogo },
+  [ProviderType.ORCID]: { displayName: 'ORCiD', path: 'orcid', icon: OrcidLogo },
+  [ProviderType.GITHUB]: { displayName: 'GitHub', path: 'github', icon: GitHubLogo },
+  [ProviderType.LINKEDIN]: { displayName: 'LinkedIn', path: 'linkedin', icon: LinkedInLogo },
+  // Facebook will be hidden until provider implementation is fixed in Ego https://github.com/overture-stack/ego/issues/555
+  // [ProviderType.FACEBOOK]: { displayName: 'Facebook', path: '', icon: FacebookLogo },
+};
+
+export default providerMap;


### PR DESCRIPTION
Display correct provider type names on `Authenticated with` label
Clean up provider typing and details