### PR TITLE
update readme to help setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,36 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-You must use npm v8.3.0 at a minimum to ensure dependency overrides work.
-You can update npm with `npm update -g npm`
-Minimum version comes bundled with Node v17.3.0 (https://nodejs.org/dist/index.json)
+This app has been tested using NodeJS version ^16, and it may not work correctly on versions <14.
 
-First, run the development server:
+We strongly recommend using the supported version.
+
+### Development Setup
+
+Setting up the project, and running a development server
 
 ```bash
-npm run dev
-# or
-yarn dev
+# 1. install the dependencies
+  npm ci
+
+# 2. serve the application
+  npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Then open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+
+This app has been tested using Node v16+. We recommend using this version if you encounter any issues.
+
+### Troubleshooting Note:
+
+DMS-UI requires NPM v^8.3.0, to ensure all dependencies are installed correctly
+
+```bash
+# If you need to update your NPM version first, use the following command:
+  npm i -g npm
+```
 
 ## Learn More
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@emotion/babel-preset-css-prop": "^10.0.27",
         "@emotion/core": "^10.0.35",
         "@emotion/styled": "^10.0.27",
-        "@types/lodash": "^4.14.168",
         "axios": "^0.25.0",
         "emotion-theming": "^10.0.27",
         "jsonwebtoken": "^8.5.1",
@@ -29,6 +28,7 @@
         "url-join": "^4.0.1"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.178",
         "@types/node": "^14.10.1",
         "@types/react": "^16.14.23",
         "@types/react-dom": "^17.0.11",
@@ -36,7 +36,7 @@
         "typescript": "^4.0.2"
       },
       "engines": {
-        "node": ">=16",
+        "node": ">=16.3.0",
         "npm": ">=8.3.0"
       }
     },
@@ -2307,7 +2307,8 @@
     "node_modules/@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -13849,7 +13850,8 @@
     "@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
-    "@types/lodash": "^4.14.168",
     "axios": "^0.25.0",
     "emotion-theming": "^10.0.27",
     "jsonwebtoken": "^8.5.1",
@@ -30,6 +29,7 @@
     "url-join": "^4.0.1"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.178",
     "@types/node": "^14.10.1",
     "@types/react": "^16.14.23",
     "@types/react-dom": "^17.0.11",
@@ -48,7 +48,6 @@
     "react-dom": "^17.0.2"
   },
   "engines": {
-    "node": ">=16",
     "npm": ">=8.3.0"
   }
 }


### PR DESCRIPTION
As this PR removes the enforcement of Node versions (since we only really care about the NPM version),
I'm updating the readme to recommend emphatically using Node 16+, and beef up the setup instructions for users to onboard more quickly.