### PR TITLE
Refactor of tabsContext to use generic tab keys

### DIFF
--- a/global/utils/typeUtils.ts
+++ b/global/utils/typeUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Strip aliases out from the top level of the TS reported type.
+ * This will display type as an object with {key: value} pairs instead as an alias name.
+ */
+export type Clean<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+
+/**
+ * Keys of an object type, as a union.
+ *
+ * Example:
+ * ```
+ * const model = { a: 'hello', b: 100};
+ * type ModelKeys = Keys<typeof model>; // "a" | "b"
+ * ```
+ */
+export type Keys<T> = T extends infer U ? keyof U : never;
+
+/**
+ * Values of an object's property types, as a union.
+ * If the object is readonly (ie. `as const`) the values will be read as literals
+ *
+ * Example:
+ * ```
+ * const model = { a: 'hello', b: 100};
+ * type ModelValues = Values<typeof model>; // string | number
+ *
+ * const modelAsConst = { a: 'hello', b: 100} as const;
+ * type ModelAsConstValues = Values<typeof modelAsConst>; // 'hello' | 100
+ * ```
+ */
+export type Values<T> = T extends infer U ? U[keyof U] : never;


### PR DESCRIPTION
This is just an example meant to show the diff for an example refactor.

There is no need to merge this as we can use a dedicated list of tabs instead of the generic, but I wanted to capture this example refactor anyways.